### PR TITLE
def configNetworkGroup() is updated to handle numberOfAddresses arg

### DIFF
--- a/RestApi/Python/Modules/IxNetRestApiProtocol.py
+++ b/RestApi/Python/Modules/IxNetRestApiProtocol.py
@@ -1322,6 +1322,9 @@ class Protocol(object):
             data={'value': kwargs['prefixLength']}
             self.ixnObj.configMultivalue(multivalue, 'singleValue', data)
 
+        if 'numberOfAddresses' in kwargs:
+            self.ixnObj.patch(self.ixnObj.httpHeader+ipv4PrefixObj, data={'numberOfAddresses': kwargs['numberOfAddresses']})
+
         return ipv4PrefixObj
 
     def configPrefixPoolsIsisL3RouteProperty(self, prefixPoolsObj, **data):


### PR DESCRIPTION
This is request from SnapRoute - case 823441 "We would like to use “Address Count” to specify the no. of routes we want to advertise in a BGP session. "