### PR TITLE
add configTrafficPacketLossDuration to Traffic Class

### DIFF
--- a/RestApi/Python/Modules/IxNetRestApiTraffic.py
+++ b/RestApi/Python/Modules/IxNetRestApiTraffic.py
@@ -502,6 +502,10 @@ class Traffic(object):
         # mode    = storeForward|cutThrough|forwardDelay|mef
         self.ixnObj.patch(self.ixnObj.sessionUrl+'/traffic/statistics/latency', data={'enabled':enabled, 'mode':mode})
 
+    def configTrafficPacketLossDuration(self, enabled=False):
+        # enabled = True|False
+        self.ixnObj.patch(self.ixnObj.sessionUrl+'/traffic/statistics/packetLossDuration', data={'enabled':enabled})
+
     def showProtocolTemplates(self, configElementObj):
         """
         Description


### PR DESCRIPTION

## Summary

```
PATCH https://<host>/api/v1/sessions/<id>/ixnetwork/<parent id>/packetLossDuration/<id>
content-type: application/json

{
  "enabled": "<bool>"
}

default is False
```

## Usage

sample code

```python
from IxNetRestApi import *
from IxNetRestApiTraffic import Traffic

try:

    mainObj = Connect(<parameters>)

    trafficObj = Traffic(mainObj)
    trafficObj.configTrafficPacketLossDuration(enabled=True)

```

sample logs

```
17:46:22.363990:
        PATCH: https://172.16.32.60/api/v1/sessions/27/ixnetwork/traffic/statistics/packetLossDuration
        DATA: {'enabled': True}
        HEADERS: {'content-type': 'application/json', 'x-api-key': 'maskedstring......'}
        STATUS CODE: 200


18:55:58.707599: checkTrafficState: Done


Row: 1
        Tx Port: Port1_15
        Rx Port: Port1_16
        Traffic Item: Topo1 to Topo2
        Source/Dest Port Pair: Port1_15-Port1_16
        Tx Frames: 2546397942
        Rx Frames: 2546397883
        Frames Delta: 59
        Loss %: 0
        Packet Loss Duration (ms): 0.07                    ### enabled PacketLossDuration !!!
        Tx Frame Rate: 0
        Rx Frame Rate: 0
        Tx L1 Rate (bps): 0
        Rx L1 Rate (bps): 0
        Rx Bytes: 325938929024
        Tx Rate (Bps): 0
        Rx Rate (Bps): 0
        Tx Rate (bps): 0
        Rx Rate (bps): 0
        Tx Rate (Kbps): 0
        Rx Rate (Kbps): 0
        Tx Rate (Mbps): 0
        Rx Rate (Mbps): 0
        Store-Forward Avg Latency (ns): 1433
        Store-Forward Min Latency (ns): 1355
        Store-Forward Max Latency (ns): 8980
        First TimeStamp: 00:00:01.069
        Last TimeStamp: 00:50:16.005
```