### PR TITLE
fixed minor errors reported by user Ashlesh.   I did basic unit testing.

### DIFF
--- a/RestApi/Python/Modules/IxNetRestApi.py
+++ b/RestApi/Python/Modules/IxNetRestApi.py
@@ -211,9 +211,9 @@ class Connect:
             self.httpScheme = 'http'
 
             if self.apiServerPort is None:
-                self.apiServerPort == 11009
+                self.apiServerPort = 11009
             else:
-                self.apiServerPort == serverIpPort
+                self.apiServerPort = serverIpPort
 
         # windowsConnectionMgr supports only https and allows users to set the SSL port.
         # This is the only api server that requires user to state httpsSecured=True|False because 8.40 users could be using http.
@@ -1112,9 +1112,7 @@ class Connect:
         """
         response = self.get(self.sessionUrl)
         sessionIdDict = {}
-        from pprint import pprint
-        pprint(response.json())
-        return
+
         for session in response.json():
             href = session['links'][0]['href']
             id = session['id']

--- a/RestApi/Python/Modules/IxNetRestApiPortMgmt.py
+++ b/RestApi/Python/Modules/IxNetRestApiPortMgmt.py
@@ -415,7 +415,7 @@ class PortMgmt(object):
         [data["arg1"].append({"arg1":str(chassis), "arg2":str(card), "arg3":str(port)}) for chassis,card,port in portList]
         url = self.ixnObj.sessionUrl+'/operations/assignports'
         response = self.ixnObj.post(url, data=data)
-        response = self.ixnObj.waitForComplete(response, url + '/' + response.json()['id'], silentMode=False, timeout=900, ignoreException=True)
+        response = self.ixnObj.waitForComplete(response, url + '/' + response.json()['id'], silentMode=False, timeout=timeout, ignoreException=True)
 
         # Ignore these verifications.  Avoid trying to resolve too many issues.
         '''


### PR DESCRIPTION
•	In file RestApi/Python/Modules/IxNetRestApiPortMgmt.py the following code uses 300 instead of timeout that is passed in argument list of function assignPorts:
•	response = self.ixnObj.waitForComplete(response, url + '/' + response.json()['id'], silentMode=False, timeout=300, ignoreException=True)
•	In file RestApi/Python/Modules/IxNetRestApi.py, == is used in the function __init__ of class Connect:
•	  if self.serverOs == 'windows':
•	      self.logInfo('Connecting to API server: windows')
•	      self.httpScheme = 'http'
•	
•	      if self.apiServerPort is None:
•	          self.apiServerPort == 11009
•	      else:
•	          self.apiServerPort == serverIpPort
•	In RestApi/Python/Modules/IxNetRestApi.py in function getAllOpenSessionIds, pprint and return should be removed:
•	 from pprint import pprint
•	 pprint(response.json())
•	 return
