### PR TITLE
fixed addTimestampToFile that was returning new filenames without the original filename 

### DIFF
--- a/RestPy/SampleScripts/loadQuickTest.py
+++ b/RestPy/SampleScripts/loadQuickTest.py
@@ -123,7 +123,7 @@ def addTimestampToFile(rfcTest, filename):
 
     newFilename = filename.split('.')[0]
     newFileExtension = filename.split('.')[1]
-    newFileWithTimestamp = '{}_{}.{}'.format(rfcTest, currentTimestamp,  newFileExtension)
+    newFileWithTimestamp = '{}_{}_{}.{}'.format(rfcTest, newFilename, currentTimestamp,  newFileExtension)
     return newFileWithTimestamp
 
     ixNetworkVersion = ixNetwork.Globals.BuildNumber


### PR DESCRIPTION
Made change to RestPy/SampleScripts/loadQuickTest.py function addTimestampToFile:
restoring newFilename to the full newFileWithTimestamp in the addTimestampToFile function. 
It was removed in commit 6a82f5e576815d6f9e10d38b0d25aa4d8d753777